### PR TITLE
add note to helptext about trailing slash

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -1964,7 +1964,7 @@ end
 
 if w.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE, SCRIPT_DESC, "unload", "UTF-8") then
     local settings = {
-        homeserver_url= {'https://matrix.org/', 'Full URL including port to your homeserver or use default matrix.org'},
+        homeserver_url= {'https://matrix.org/', 'Full URL including port to your homeserver (including trailing slash) or use default matrix.org'},
         user= {'', 'Your homeserver username'},
         password= {'', 'Your homeserver password'},
         backlog_lines= {'120', 'Number of lines to fetch from backlog upon connecting'},


### PR DESCRIPTION
This confused me for a hot second, seeing as the web client, for example, requires no trailing slash. If I knew more lua, I'd just make it do the right thing, but this at least explains that it's needed.