### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ weechat
 ```
 
 ```
-/lua load matrix.lua
+/script load matrix.lua
 /set plugins.var.lua.matrix.user username
 /set plugins.var.lua.matrix.password secret
 /matrix connect


### PR DESCRIPTION
/language is no longer used to load scripts in recent versions. It has been replaced by /script.
