### PR TITLE
Return httpversion as a string, not a number

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -464,7 +464,7 @@ local function parse_http_statusline(line)
     if not httpversion then
         return
     end
-    return tonumber(httpversion), tonumber(status_code), reason_phrase
+    return httpversion, tonumber(status_code), reason_phrase
 end
 
 function real_http_cb(extra, command, rc, stdout, stderr)


### PR DESCRIPTION
tonumber fails on "1.1" in locales where "," is used as the decimal
separator.  The HTTP version isn't actually used for anything, so just
return it as a string.