### PR TITLE
Use full path for curl to prevent bugs or code execution in case $PATH would be overwritten

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -1574,7 +1574,7 @@ function MatrixServer:Upload(room_id, filename)
     local url = w.config_get_plugin('homeserver_url') ..
         ('_matrix/media/r0/upload?access_token=%s')
         :format( urllib.quote(SERVER.access_token) )
-    w.hook_process_hashtable('curl', {
+    w.hook_process_hashtable('/usr/bin/curl', {
         arg1 = '--data-binary', -- no encoding of data
         arg2 = '@'..filename, -- @means curl will load the filename
         arg3 = '-XPOST', -- HTTP POST method


### PR DESCRIPTION
When invoking OS commands, one should always use the full path to the binary. If someone were able to overwrite $PATH, he could achieve code execution, when placing another `curl` binary in another path