### PR TITLE
Replace leading double slash with single slash in message

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -1655,6 +1655,7 @@ end
 function buffer_input_cb(b, buffer, data)
     for r_id, room in pairs(SERVER.rooms) do
         if buffer == room.buffer then
+            data = data:gsub('^//', '/')
             SERVER:Msg(r_id, data)
             break
         end


### PR DESCRIPTION
This is in line with the behaviour of the irc plugin, when I want to send `/kaas` I have to type `//kaas`, otherwise weechat will think my message is a command. With the native IRC plugin when I enter `//kaas`, `/kaas` will be sent. But with this script `//kaas` would've been sent.

This PR fixes that by just replacing a double leading slash with a single one before handing it to `Room:Msg`.