### PR TITLE
Fix italic and bolding WeeChat->Matrix

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -245,8 +245,8 @@ local function irc_formatting_to_html(s)
         'orange','yellow','lightgreen','teal','cyan', 'lightblue',
         'fuchsia', 'gray', 'lightgray'}
 
-    s = byte_to_tag(s, '\02', '<em>', '</em>')
-    s = byte_to_tag(s, '\029', '<i>', '</i>')
+    s = byte_to_tag(s, '\02', '<strong>', '</strong>')
+    s = byte_to_tag(s, '\029', '<em>', '</em>')
     s = byte_to_tag(s, '\031', '<u>', '</u>')
     -- First do full color strings with reset.
     -- Iterate backwards to catch long colors before short


### PR DESCRIPTION
Issue reported in #riot:matrix.org by @PureTryOut:matrix.org

Bold would show up as Italic \<em\>
Italic would look correct but use \<i\>

![image](https://cloud.githubusercontent.com/assets/2403652/24864507/5cde4b4e-1dfc-11e7-90a4-fa3b052ca24e.png)

![image](https://cloud.githubusercontent.com/assets/2403652/24864497/5835ffd8-1dfc-11e7-8b92-af7c7f45cb63.png)

