### PR TITLE
Revert "Use full path for curl to prevent bugs or code"

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -1576,7 +1576,7 @@ function MatrixServer:Upload(room_id, filename)
     local url = w.config_get_plugin('homeserver_url') ..
         ('_matrix/media/r0/upload?access_token=%s')
         :format( urllib.quote(SERVER.access_token) )
-    w.hook_process_hashtable('/usr/bin/curl', {
+    w.hook_process_hashtable('curl', {
         arg1 = '--data-binary', -- no encoding of data
         arg2 = '@'..filename, -- @means curl will load the filename
         arg3 = '-XPOST', -- HTTP POST method


### PR DESCRIPTION
This reverts commit 738e5d12dcff2a1be764c31530e7318d22096c60, pull request #57.

The $PATH environment variable exists specifically for the purpose of looking-
up binaries' locations in a system-independent manner. If $PATH is overwritten,
which the user has full discretion to do, then so be it. If the $PATH is
overwritten by compromise, then the system itself is already compromised and
this change prevents nothing.
Furthermore, many operating systems install packages and user-compiled software
into PREFIX=/usr/local, causing this commit to break this script.

Signed-off-by: Bryce Chidester <bryce@cobryce.com>