### PR TITLE
redact access token on curl error

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -475,7 +475,7 @@ function real_http_cb(extra, command, rc, stdout, stderr)
     end
 
     if stderr and stderr ~= '' then
-        mprint(('error: %s'):format(stderr))
+        mprint(('error: %s'):format(accesstoken_redact(stderr)))
         return w.WEECHAT_RC_OK
     end
 


### PR DESCRIPTION
This can happen when your HS is down:
```
 error: erreur curl 7 (couldn't connect to host) (URL : "https://cloud.cervoi.se/_matrix/client/r0/sync?access%5Ftoken=<not redacted>
```