### PR TITLE
Update the login API JSON

### DIFF
--- a/matrix.lua
+++ b/matrix.lua
@@ -1160,10 +1160,14 @@ function MatrixServer:connect()
         w.print('', 'matrix: Connecting to homeserver URL: '..
             w.config_get_plugin('homeserver_url'))
         local post = {
-            ["type"]="m.login.password",
-            ["user"]=user,
+            ["address"]=user,
+            ["identifier.address"]=user,
+            ["identifier.medium"]="email",
+            ["identifier.type"]="m.id.thirdparty",
+            ["initial_device_display_name"]="WeeMatrix",
+            ["medium"]="email",
             ["password"]=password,
-            ['initial_device_display_name']='WeeMatrix'
+            ["type"]="m.login.password"
         }
         http('/login', {
             postfields = json.encode(post)


### PR DESCRIPTION
This change is based on a JSON riot.im sends to the server to login into
it. The json riot.im sends it is different from the official JSON API
documentation. So I have found this doc where there is a proposal for a
change:

https://docs.google.com/document/d/1-6ZSSW5YvCGhVFDyD2QExAUAdpCWjccvJT5xiyTTG2Y/
edit#

There is another link where the docs are updated:
https://kamax.io/matrix/api/client_server/unstable.html#
post-matrix-client-r0-login

Fixes #113